### PR TITLE
[feat/#89] LCP 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,14 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="/fonts/pretendard/pretendard.css" />
+    <link
+      rel="preconnect"
+      href="https://s3.ap-northeast-2.amazonaws.com"
+      crossorigin />
+    <link rel="dns-prefetch" href="https://s3.ap-northeast-2.amazonaws.com" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>IDUS</title>
   </head>

--- a/src/pages/product-info/components/carousel/carousel.tsx
+++ b/src/pages/product-info/components/carousel/carousel.tsx
@@ -63,6 +63,8 @@ export const Carousel = ({ images, price, rate }: CarouselProps) => {
               key={`${image}-${index}`}
               src={image}
               alt={`상품이미지 ${index}`}
+              // LCP 최적화: 첫 번째 이미지(index 1)는 우선 로드
+              fetchPriority={index === 1 ? "high" : "auto"}
             />
           ))}
         </div>


### PR DESCRIPTION
## 📌 Summary

- close #89

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## 📄 Tasks

- Lighthouse 성능 테스트 결과 Performance 점수가 상대적으로 낮았고, 원인은 캐러셀 이미지 LCP 때문이었어요. 따라서 프론트측에서 LCP를 최적화할 수 있는 설정을 추가했어요. LCP가 커지는 근본적인 원인은 서버에서 보내주는 이미지 사이즈 크기때문이라 서버에서 `png`를 `webp`로 바꾸면 되겠지만 그건 프론트측 성능 최적화는 아니다보니 그냥 프론트에서 적용 가능한 몇 가지 최적화 코드 추가했습니다ㅎㅎ
- 서버에서 `png` 이미지를 받은 뒤 프론트측에서 `webp`로 바꾸는건 의미가 없어 적용하지 않았어요. Performance 탭에서 `LCP Breakdown`을 확인해보면 LCP 중 95%가 Resource Load Duration, 즉 서버에서 이미지를 다운로드하는 데 걸리는 시간이므로 서버에서 이미지를 로드한 뒤 프론트에서 이미지 포맷을 바꿔 용량을 줄여도 LCP는 개선되지 않아요.
- 자세한 내용은 챌린징 이슈 아티클에서 작성하겠습니다!

https://sand-knot-d9d.notion.site/LCP-31db555a2dff809b854eed8661ad35a4?source=copy_link

_해당 PR에 수행한 작업을 작성해주세요._

## 🔍 To Reviewer

-

_리뷰어에게 요청하는 내용을 작성해주세요._

## 📸 Screenshot

-

_작업한 내용에 대한 스크린샷을 첨부해주세요._
